### PR TITLE
Mn 2017 08 add links in helptexts

### DIFF
--- a/apps/ideas/forms.py
+++ b/apps/ideas/forms.py
@@ -3,10 +3,9 @@ from itertools import chain
 import crispy_forms as crisp
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
-from cms.settings.models import HelpPages
+from cms.contrib import helpers
 
 from . import models
 from .models.abstracts.applicant_section import AbstractApplicantSection
@@ -20,8 +19,6 @@ from .models.abstracts.impact_section import AbstractImpactSection
 from .models.abstracts.partners_section import AbstractPartnersSection
 from .models.abstracts.selection_criteria_section import \
     AbstractSelectionCriteriaSection
-
-LINK_TEXT = _('Please look {}here{} for more information.')
 
 ACCEPT_CONDITIONS_LABEL = _('I hereby confirm and agree that '
                             'my idea will be public once'
@@ -183,23 +180,13 @@ class ImpactSectionForm(BaseForm):
         ]
 
     def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop('request', None)
         super().__init__(*args, **kwargs)
-        help_pages = HelpPages.for_site(self.request.site)
-        if (help_pages.annual_theme_help_page and
-                help_pages.annual_theme_help_page.live):
-            url = help_pages.annual_theme_help_page.url
-            current_outcome_help_text = self.fields['outcome'].help_text
-            current_challenge_help_text = self.fields['challenge'].help_text
-            current_plan_help_text = self.fields['plan'].help_text
-            link_text = LINK_TEXT \
-                .format('<a href="' + url + '" target="_blank">', '</a>')
-            self.fields['outcome'].help_text = '{} {}'.format(
-                current_outcome_help_text, mark_safe(link_text))
-            self.fields['challenge'].help_text = '{} {}'.format(
-                current_challenge_help_text, mark_safe(link_text))
-            self.fields['plan'].help_text = '{} {}'.format(
-                current_plan_help_text, mark_safe(link_text))
+        self.fields['outcome'].help_text = helpers.add_link_to_helptext(
+            self.fields['outcome'].help_text, "annual_theme_help_page")
+        self.fields['challenge'].help_text = helpers.add_link_to_helptext(
+            self.fields['challenge'].help_text, "annual_theme_help_page")
+        self.fields['plan'].help_text = helpers.add_link_to_helptext(
+            self.fields['plan'].help_text, "annual_theme_help_page")
 
 
 class CollaborationCampSectionForm(BaseForm):
@@ -215,20 +202,11 @@ class CollaborationCampSectionForm(BaseForm):
         ]
 
     def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop('request', None)
         super().__init__(*args, **kwargs)
-        help_pages = HelpPages.for_site(self.request.site)
-        if (help_pages.communication_camp_help_page and
-                help_pages.communication_camp_help_page.live):
-            url = help_pages.communication_camp_help_page.url
-            current_collaboration_camp_option_help_text = \
-                self.fields['collaboration_camp_option'].help_text
-            link_text = LINK_TEXT.format(
-                '<a href="' + url + '" target="_blank">', '</a>')
-            self.fields['collaboration_camp_option'].help_text = \
-                '{} {}'.format(
-                current_collaboration_camp_option_help_text,
-                    mark_safe(link_text))
+        self.fields['collaboration_camp_option'].help_text \
+            = helpers.add_link_to_helptext(
+            self.fields['collaboration_camp_option'].help_text,
+            "communication_camp_help_page")
 
 
 class CommunitySectionForm(CollaboratorsEmailsFormMixin, BaseForm):

--- a/apps/ideas/models/abstracts/collaboration_camp_section.py
+++ b/apps/ideas/models/abstracts/collaboration_camp_section.py
@@ -6,9 +6,7 @@ COLLABORATION_CAMP_OPTIONS_CHOICES = (
     ('partner_track', 'Partner track'),
     ('not_sure', "I'm not sure yet")
 )
-COLLABORATION_CAMP_OPTIONS_HELP = _('Choose one of the following options. '
-                                    'More information about the two tracks '
-                                    'is available here: (Link).')
+COLLABORATION_CAMP_OPTIONS_HELP = _('Choose one of the following options.')
 COLLABORATION_CAMP_REPRESENT_TITLE = _('Who will represent your idea '
                                        'at the Collaboration Camp and why?')
 COLLABORATION_CAMP_REPRESENT_HELP = _('(Specify one person only. '

--- a/apps/ideas/models/abstracts/impact_section.py
+++ b/apps/ideas/models/abstracts/impact_section.py
@@ -2,16 +2,11 @@ from django.db import models
 from django.utils.translation import ugettext as _
 
 CHALLENGE_TITLE = _('What problem or societal need are you working on?')
-CHALLENGE_HELP = _('Please look here for more information about the '
-                   'annual theme: (link to subpage with more '
-                   'detailed explanation of the annual theme). '
-                   '(max. 300 characters)')
+CHALLENGE_HELP = _('max. 300 characters.')
 OUTCOME_TITLE = _('What would be a successful outcome for your project?')
 OUTCOME_HELP = _('If your project is selected, what will be different '
-                 'a year from now? What will have changed? Please look '
-                 'here for more information: (link to subpage '
-                 'with explanation on impact). '
-                 '(max. 300 characters)')
+                 'a year from now? What will have changed? '
+                 '(max. 300 characters).')
 PLAN_TITLE = _('How do you plan to get there? Remember to highlight'
                ' what makes your project design or idea '
                'different and innovative.')
@@ -19,9 +14,7 @@ PLAN_HELP = _('Describe as concretely as possible the '
               'approach and / or the method '
               'you will use when implementing your idea. '
               'What are the steps you plan '
-              'to take? Please look here for more information: '
-              '(link to subpage on with explanation on implementation). '
-              '(max. 500 characters)')
+              'to take? (max. 500 characters).')
 IMPORTANCE_TITLE = _('Why is this idea important to you?')
 IMPORTANCE_HELP = _('What motivates you to bring this idea to life? '
                     'What is your story? What is your personal '

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -94,11 +94,6 @@ class IdeaSketchCreateWizard(PermissionRequiredMixin,
     finish_section_text = _('You can add data or edit your idea later.')
     finish_section_btn = _('Submit your idea!')
 
-    def get_form_kwargs(self, step):
-        if step == '3' or step == '4':
-            return {'request': self.request}
-        return {}
-
     def done(self, form_list, **kwargs):
         special_fields = ['accept_conditions', 'collaborators_emails']
 
@@ -145,13 +140,6 @@ class IdeaSketchEditView(
         forms.CollaborationCampSectionForm,
         forms.CommunitySectionEditForm,
     ]
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        if self.form_number == 3 or self.form_number == 4:
-            kwargs['request'] = self.request
-            return kwargs
-        return kwargs
 
     @property
     def raise_exception(self):
@@ -226,11 +214,6 @@ class ProposalCreateWizard(PermissionRequiredMixin,
     finish_section_text = _('You can add data or edit your proposal later.')
     finish_section_btn = _('Submit your proposal!')
 
-    def get_form_kwargs(self, step):
-        if step == '3':
-            return {'request': self.request}
-        return {}
-
     def get_form_initial(self, step):
         initial = self.initial_dict.get(step, {})
         form = self.form_list[step]
@@ -294,13 +277,6 @@ class ProposalEditView(
         forms.FinanceAndDurationSectionForm,
         forms.CommunitySectionEditForm,
     ]
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        if self.form_number == 3:
-            kwargs['request'] = self.request
-            return kwargs
-        return kwargs
 
     @property
     def raise_exception(self):

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -94,6 +94,11 @@ class IdeaSketchCreateWizard(PermissionRequiredMixin,
     finish_section_text = _('You can add data or edit your idea later.')
     finish_section_btn = _('Submit your idea!')
 
+    def get_form_kwargs(self, step):
+        if step == '3' or step == '4':
+            return {'request': self.request}
+        return {}
+
     def done(self, form_list, **kwargs):
         special_fields = ['accept_conditions', 'collaborators_emails']
 
@@ -140,6 +145,13 @@ class IdeaSketchEditView(
         forms.CollaborationCampSectionForm,
         forms.CommunitySectionEditForm,
     ]
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if self.form_number == 3 or self.form_number == 4:
+            kwargs['request'] = self.request
+            return kwargs
+        return kwargs
 
     @property
     def raise_exception(self):
@@ -214,6 +226,11 @@ class ProposalCreateWizard(PermissionRequiredMixin,
     finish_section_text = _('You can add data or edit your proposal later.')
     finish_section_btn = _('Submit your proposal!')
 
+    def get_form_kwargs(self, step):
+        if step == '3':
+            return {'request': self.request}
+        return {}
+
     def get_form_initial(self, step):
         initial = self.initial_dict.get(step, {})
         form = self.form_list[step]
@@ -277,6 +294,13 @@ class ProposalEditView(
         forms.FinanceAndDurationSectionForm,
         forms.CommunitySectionEditForm,
     ]
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if self.form_number == 3:
+            kwargs['request'] = self.request
+            return kwargs
+        return kwargs
 
     @property
     def raise_exception(self):

--- a/cms/contrib/helpers.py
+++ b/cms/contrib/helpers.py
@@ -1,0 +1,24 @@
+from django.utils.html import mark_safe
+from django.utils.translation import ugettext_lazy as _
+from wagtail.wagtailcore.models import Site
+
+from cms.settings.models import HelpPages
+
+LINK_TEXT = _('Please look {}here{} for more information.')
+
+
+def add_link_to_helptext(help_text, help_page_name):
+    site = Site.objects.filter(
+        is_default_site=True
+    ).first()
+    help_pages = HelpPages.for_site(site)
+
+    if getattr(help_pages, help_page_name) and \
+       getattr(help_pages, help_page_name).live:
+        url = getattr(help_pages, help_page_name).url
+        link_text = LINK_TEXT \
+            .format('<a href="' + url + '" target="_blank">', '</a>')
+        return '{} {}'.format(
+                help_text, mark_safe(link_text))
+
+    return help_text

--- a/cms/settings/migrations/0002_helppages.py
+++ b/cms/settings/migrations/0002_helppages.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0039_collectionviewrestriction'),
+        ('cms_settings', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='HelpPages',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', auto_created=True, primary_key=True)),
+                ('annual_theme_help_page', models.ForeignKey(null=True, related_name='help_page_annual_theme', help_text='Please add a link to the page that explains the annual theme, impact and implementation.', to='wagtailcore.Page', on_delete=django.db.models.deletion.SET_NULL)),
+                ('communication_camp_help_page', models.ForeignKey(null=True, related_name='help_page_communication_camp', help_text='Please add a link to the page that explains the communication camp here.', to='wagtailcore.Page', on_delete=django.db.models.deletion.SET_NULL)),
+                ('site', models.OneToOneField(editable=False, to='wagtailcore.Site')),
+                ('terms_of_use_page', models.ForeignKey(null=True, related_name='help_page_terms_of_use_page', help_text='Please add a link to the page that explains the terms of condition here.', to='wagtailcore.Page', on_delete=django.db.models.deletion.SET_NULL)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/cms/settings/models.py
+++ b/cms/settings/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from wagtail.contrib.settings.models import BaseSetting, register_setting
+from wagtail.wagtailadmin.edit_handlers import PageChooserPanel
 
 
 @register_setting
@@ -11,4 +12,32 @@ class SocialMediaSettings(BaseSetting):
     flickr = models.URLField(
         help_text='Your flickr page URL', blank=True)
     youtube = models.URLField(
-        help_text='Your YouTube channel or user account URL' , blank=True)
+        help_text='Your YouTube channel or user account URL', blank=True)
+
+
+@register_setting
+class HelpPages(BaseSetting):
+    communication_camp_help_page = models.ForeignKey(
+        'wagtailcore.Page',
+        related_name="help_page_communication_camp",
+        null=True,
+        on_delete=models.SET_NULL,
+        help_text="Please add a link to the page that explains the communication camp here.")
+    annual_theme_help_page = models.ForeignKey(
+        'wagtailcore.Page',
+        related_name="help_page_annual_theme",
+        null=True,
+        on_delete=models.SET_NULL,
+        help_text="Please add a link to the page that explains the annual theme, impact and implementation.")
+    terms_of_use_page = models.ForeignKey(
+        'wagtailcore.Page',
+        related_name="help_page_terms_of_use_page",
+        null=True,
+        on_delete=models.SET_NULL,
+        help_text="Please add a link to the page that explains the terms of condition here.")
+
+    panels = [
+        PageChooserPanel('communication_camp_help_page'),
+        PageChooserPanel('annual_theme_help_page'),
+        PageChooserPanel('terms_of_use_page'),
+    ]

--- a/tests/ideas/test_idea_views.py
+++ b/tests/ideas/test_idea_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.exceptions import PermissionDenied
+from django.core.urlresolvers import reverse
 
 from apps.ideas import models, views
 
@@ -76,3 +77,23 @@ def test_idea_export_view_admin(rf, admin, idea_sketch_factory,
     assert len(str(content_line[0]).split('","')) == 58
     assert len(str(content_line[1]).split('","')) == 58
     assert len(str(content_line[3]).split('","')) == 58
+
+
+@pytest.mark.django_db
+def test_idea_sketch_edit_form_has_request(admin, idea_sketch_factory, client):
+    client.login(email=admin.email, password='password')
+    idea_sketch = idea_sketch_factory()
+    url = reverse('idea-sketch-update-form',
+                  kwargs={'slug': idea_sketch.slug, 'form_number': '3'})
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_proposal_edit_form_has_request(admin, proposal_factory, client):
+    client.login(email=admin.email, password='password')
+    proposal = proposal_factory()
+    url = reverse('proposal-update-form',
+                  kwargs={'slug': proposal.slug, 'form_number': '3'})
+    response = client.get(url)
+    assert response.status_code == 200


### PR DESCRIPTION
fixes #108 

This adds links to pages that are editable in wagtail to helptexts in ideasketch and proposal forms. 

To get this working:

- go to wagtail admin -> settings -> help pages 
- set the pages

Then when creating or editing an ideasketch or proposal within some of the forms are some links in the helptext.
