### PR TITLE
Mn 2017 08 fix headerimage

### DIFF
--- a/advocate_europe/assets/scss/components/_herounit.scss
+++ b/advocate_europe/assets/scss/components/_herounit.scss
@@ -75,7 +75,7 @@
     }
 
     @media screen and (max-width: $screen-xs) {
-        font-size: rem($font-size-base);
+        font-size: rem(24px);
         padding: rem(0 10px);
     }
 
@@ -106,6 +106,10 @@
 
     @media screen and (max-width: $screen-sm-max) {
         padding: 0;
+    }
+
+    @media screen and (max-width: $screen-xs) {
+        font-size: rem(18px);
     }
 }
 

--- a/advocate_europe/assets/scss/components/_herounit.scss
+++ b/advocate_europe/assets/scss/components/_herounit.scss
@@ -16,7 +16,6 @@
     }
 
     &:after {
-        background: rgba(0, 0, 0, 0.5);
         content: '\A';
         left: 0;
         min-height: 100%;
@@ -48,6 +47,11 @@
     color: #fff;
     position: relative;
     z-index: 1;
+
+    @media screen and (min-width: $screen-sm-max) {
+        padding-left: 33%;
+    }
+
 
     .button {
         margin-top: rem(13px);

--- a/cms/home/templates/cms_home/includes/home_hero_unit.html
+++ b/cms/home/templates/cms_home/includes/home_hero_unit.html
@@ -1,11 +1,11 @@
 {% load i18n wagtailimages_tags wagtailembeds_tags static %}
-{% image image width-768 as smallImage %}
-{% image image original as originalImage %}
+{% image image fill-768x500 as smallImage %}
+{% image image fill-1700x500-c100 as bigImage %}
 <header class="herounit">
-    <div class="herounit-image visible-lg visible-xl" style="background-image: url({{ originalImage.url }})"></div>
+    <div class="herounit-image visible-lg visible-xl" style="background-image: url({{ bigImage.url }})"></div>
     <div class="herounit-image visible-xs visible-sm visible-md" style="background-image: url({{ smallImage.url }})"></div>
     <div class="container">
-        <div class="container-narrow">
+        <div class="container">
             <div class="herounit-header">
                 <h1 class="herounit-title">{{ title }}</h1>
                 <div class="herounit-content">


### PR DESCRIPTION
based on the feedback, I:

- removed the grey layer above the header image on the landing page
- moved the text box within the header on the landing page more to the right on bigger screens
- make wagtail cut the background image based on the focal point (This fixes the issue, that on large screens the eyes of that woman are cut off, to test got to wagtail images and set the focal point around the face of the woman ) 