### PR TITLE
save m2m fields after model was saved

### DIFF
--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -236,10 +236,15 @@ class ProposalCreateWizard(PermissionRequiredMixin,
         for field in archive._meta.get_fields():
             value = getattr(self.idea.ideasketch, field.name)
 
+            if not (field.many_to_many or field.one_to_many):
+                setattr(archive, field.name, value)
+        archive.save()
+
+        for field in archive._meta.get_fields():
+            value = getattr(self.idea.ideasketch, field.name)
             if field.many_to_many or field.one_to_many:
                 value = value.all()
-
-            setattr(archive, field.name, value)
+                setattr(archive, field.name, value)
 
         archive.save()
 


### PR DESCRIPTION
fixes #289 

The Bug only happened on my machine locally - Postgres db, could not reproduce on dev server (Thats Postgres also, right?). Strange. 