### PR TITLE
perm add_proposal checks if proposal already exists

### DIFF
--- a/apps/ideas/predicates.py
+++ b/apps/ideas/predicates.py
@@ -12,6 +12,11 @@ def is_on_shortlist(user, idea):
 
 
 @rules.predicate
+def has_no_proposal(user, idea):
+    return not hasattr(idea, 'proposal')
+
+
+@rules.predicate
 def is_winner(user, obj):
     if hasattr(obj, 'is_winner'):
         return obj.is_winner

--- a/apps/ideas/rules.py
+++ b/apps/ideas/rules.py
@@ -37,6 +37,7 @@ rules.add_perm(
         predicates.is_collaborator
     ) &
     predicates.is_on_shortlist &
+    predicates.has_no_proposal &
     phase_predicates.phase_allows_change
 )
 

--- a/apps/ideas/templates/advocate_europe_ideas/idea_detail.html
+++ b/apps/ideas/templates/advocate_europe_ideas/idea_detail.html
@@ -53,7 +53,7 @@
                             {% elif can_change_proposal %}
                             <li><a href="{% url 'proposal-update' idea.slug %}">{% trans "edit proposal" %}</a></li>
                             {% endif %}
-                            {% if can_add_proposal and not idea.proposal %}
+                            {% if can_add_proposal %}
                             <li><a href="{% url 'idea-sketch-add-proposal' idea.slug %}">{% trans 'add full proposal' %}</a></li>
                             {% endif %}
                         </ul>


### PR DESCRIPTION
fixes #221 
I am not entirely sure, there was the problem of reaching the create url before, and I still get a 404 instead of a 403, when I try to do so. But at least it saves us a check in the template.