### PR TITLE
Mn 2017 08 fix for admin permissions

### DIFF
--- a/apps/ideas/rules.py
+++ b/apps/ideas/rules.py
@@ -13,12 +13,12 @@ rules.add_perm(
 )
 
 rules.add_perm(
-    'advocate_europe_ideas.add_ideasketch',
+    'advocate_europe_ideas.create_ideasketch',
     mod_predicates.is_allowed_add_item(models.IdeaSketch)
 )
 
 rules.add_perm(
-    'advocate_europe_ideas.change_idea',
+    'advocate_europe_ideas.update_idea',
     mod_predicates.is_project_admin |
     mod_predicates.is_context_member &
     (
@@ -29,7 +29,7 @@ rules.add_perm(
 )
 
 rules.add_perm(
-    'advocate_europe_ideas.add_proposal',
+    'advocate_europe_ideas.create_proposal',
     mod_predicates.is_project_admin |
     mod_predicates.is_context_member &
     (

--- a/apps/ideas/templates/advocate_europe_ideas/idea_detail.html
+++ b/apps/ideas/templates/advocate_europe_ideas/idea_detail.html
@@ -34,10 +34,10 @@
                     </a>
 
                     {% if idea.proposal %}
-                        {% has_perm 'advocate_europe_ideas.change_idea' request.user idea as can_change_proposal %}
+                        {% has_perm 'advocate_europe_ideas.update_idea' request.user idea as can_change_proposal %}
                     {% elif idea.ideasketch %}
-                        {% has_perm 'advocate_europe_ideas.change_idea' request.user idea.ideasketch as can_change_sketch %}
-                        {% has_perm 'advocate_europe_ideas.add_proposal' request.user idea as can_add_proposal %}
+                        {% has_perm 'advocate_europe_ideas.update_idea' request.user idea.ideasketch as can_change_sketch %}
+                        {% has_perm 'advocate_europe_ideas.create_proposal' request.user idea as can_add_proposal %}
                     {% endif %}
                     {% if can_change_sketch or can_change_proposal or can_add_proposal %}
 

--- a/apps/ideas/templates/advocate_europe_ideas/includes/call_to_action_tile.html
+++ b/apps/ideas/templates/advocate_europe_ideas/includes/call_to_action_tile.html
@@ -10,7 +10,7 @@
     </div>
     {% get_modules as modules %}
         {% if modules %}
-          {% has_perm 'advocate_europe_ideas.add_ideasketch' request.user modules.0 as can_add %}
+          {% has_perm 'advocate_europe_ideas.create_ideasketch' request.user modules.0 as can_add %}
           {% if can_add %}
           <a class="btn btn-ae-secondary call-to-action-btn" href="{% url 'idea-sketch-create' modules.0.slug %}">{% trans "Create proposal!" %}</a>
           {% endif %}

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -87,7 +87,7 @@ class IdeaSketchCreateWizard(PermissionRequiredMixin,
                              mixins.ModuleMixin,
                              wizard_mixins.CustomWizardMixin,
                              SessionWizardView):
-    permission_required = 'advocate_europe_ideas.add_ideasketch'
+    permission_required = 'advocate_europe_ideas.create_ideasketch'
     file_storage = FileSystemStorage(
         location=os.path.join(settings.MEDIA_ROOT, 'idea_sketch_images'))
     title = _('create an idea')
@@ -126,7 +126,7 @@ class IdeaSketchEditView(
     SuccessMessageMixin,
     generic.UpdateView
 ):
-    permission_required = 'advocate_europe_ideas.change_idea'
+    permission_required = 'advocate_europe_ideas.update_idea'
     model = IdeaSketch
     template_name = 'advocate_europe_ideas/idea_update_form.html'
     success_message = _('Ideasketch saved')
@@ -216,7 +216,7 @@ class ProposalCreateWizard(PermissionRequiredMixin,
                            wizard_mixins.CustomWizardMixin,
                            SessionWizardView,
                            ):
-    permission_required = 'advocate_europe_ideas.add_proposal'
+    permission_required = 'advocate_europe_ideas.create_proposal'
     file_storage = FileSystemStorage(
         location=os.path.join(settings.MEDIA_ROOT, 'idea_sketch_images'))
     title = _('create a proposal')
@@ -269,7 +269,7 @@ class ProposalEditView(
     SuccessMessageMixin,
     generic.UpdateView
 ):
-    permission_required = 'advocate_europe_ideas.change_idea'
+    permission_required = 'advocate_europe_ideas.update_idea'
     model = Proposal
     template_name = 'advocate_europe_ideas/idea_update_form.html'
     success_message = _('Proposal saved')

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -7,7 +7,7 @@ from . import models
 class UserAdmin(auth.admin.UserAdmin):
     fieldsets = (
         (None, {'fields': ('username', 'email', 'password')}),
-        (_('Permissions'), {'fields': ('is_staff', 'is_superuser')}),
+        (_('Permissions'), {'fields': ('is_staff', 'is_superuser', 'groups')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
         (_('Profile data'), {'fields': (
             '_avatar',

--- a/apps/users/templates/advocate_europe_users/indicator_menu.html
+++ b/apps/users/templates/advocate_europe_users/indicator_menu.html
@@ -12,7 +12,7 @@
             </button>
 
             <ul class="dropdown-menu user-indicator-menu">
-                {% if request.user.is_superuser %}
+                {% if request.user.is_superuser or request.user.is_staff %}
                 <li>
                     <a href="{% url 'admin:index' %}"><i class="fa fa-hand-spock-o fa-fw" aria-hidden="true"></i> <span class="dropdown-text">{% trans "Admin" %}</span></a>
                 </li>
@@ -22,7 +22,7 @@
                 </li>
                 {% get_modules as modules %}
                 {% for module in modules %}
-                    {% has_perm 'advocate_europe_ideas.add_ideasketch' request.user module as can_add %}
+                    {% has_perm 'advocate_europe_ideas.create_ideasketch' request.user module as can_add %}
                     {% if can_add %}
                     <li>
                         <a href="{% url 'idea-sketch-create' module.slug %}">


### PR DESCRIPTION
I did some research on how to create a group with limited access to the django admin interface. The problem that we have is that we use the same permission name pattern for our rules names as django uses for its permissions. 

{app_label}.add_{model_name}
{app_label}.change_{model_name}
{app_label}.delete_{model_name}

The part in Django is here: https://github.com/django/django/blob/master/django/contrib/auth/models.py#L173

In this PR I fixed it by renaming our rules for Ideas with another pattern. But this would only make sense if we changed some permission names in A4 as well, e.g. for comments, modules and phases. (We could remove and add them again with another name in our local project, but for everything thats accessible via the API this is not an option as the pattern is hard coded in the API code). 

Also if we started to rename our rules, then we should rename all of them., e.g. 'add' to 'create' , 'change' to 'edit' and 'delete' to 'remove'.

I think this could be a good way to use django admin with rules. What do you think? I would make a PR in A4.


