### PR TITLE
centered comment dots on mobile safari

### DIFF
--- a/advocate_europe/assets/scss/components/_comments.scss
+++ b/advocate_europe/assets/scss/components/_comments.scss
@@ -72,6 +72,7 @@
         margin: 0;
 
         .dropdown-toggle {
+            padding: 0;
             margin-left: rem(5px);
             border: 0;
             background-color: $ae-light-gray;


### PR DESCRIPTION
fixes #217 (tested with browser stack)