### PR TITLE
added adapter to send own account email

### DIFF
--- a/advocate_europe/settings/base.py
+++ b/advocate_europe/settings/base.py
@@ -299,7 +299,7 @@ LOGIN_REDIRECT_URL = '/'
 ACCOUNT_SIGNUP_FORM_CLASS = 'apps.users.forms.SignUpForm'
 
 
-#ACCOUNT_ADAPTER = 'apps.users.adapters.AccountAdapter'
+ACCOUNT_ADAPTER = 'apps.users.adapters.AccountAdapter'
 ACCOUNT_AUTHENTICATION_METHOD = 'email'
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 3
 ACCOUNT_EMAIL_REQUIRED = True

--- a/advocate_europe/templates/account/email/email_confirmation.en.email
+++ b/advocate_europe/templates/account/email/email_confirmation.en.email
@@ -1,0 +1,16 @@
+{% extends 'email_base.'|add:part_type %}
+
+{% block subject %}Please confirm your email address on {{ site.name }}{% endblock %}
+
+{% block headline %}Your email address on {{ site.name }}{% endblock %}
+
+{% block content %}
+Your email address has been added to the username “{{ receiver.username }}” on <i>{{ site.name }}</i>. Please click the {% if part_type == 'txt' %}link{% else %}button{% endif %} below to confirm your email address.
+{% endblock %}
+
+{% block cta_url %}{{ activate_url }}{% endblock %}
+{% block cta_label %}Confirm your email address{% endblock %}
+
+{% block reason %}
+This email was sent to {{ receiver.email }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via info@opin.me
+{% endblock %}

--- a/advocate_europe/templates/account/email/email_confirmation_signup.en.email
+++ b/advocate_europe/templates/account/email/email_confirmation_signup.en.email
@@ -1,0 +1,16 @@
+{% extends 'email_base.'|add:part_type %}
+
+{% block subject %}Please confirm your registration on {{ site.name }}{% endblock %}
+
+{% block headline %}Your registration on {{ site.name }}{% endblock %}
+
+{% block content %}
+Your email address has been used to register on <i>{{ site.name }}</i> with the username “{{ receiver.username }}”. Please click on the button below to confirm your email address and activate your account.
+{% endblock %}
+
+{% block cta_url %}{{ activate_url }}{% endblock %}
+{% block cta_label %}Confirm your email address{% endblock %}
+
+{% block reason %}
+This email was sent to {{ receiver.email }}. If you think this email was sent to you by mistake, you can ignore it. We will not send you any further emails. If you have any further questions, please contact us via info@opin.me
+{% endblock %}

--- a/advocate_europe/templates/account/email/password_reset_key.en.email
+++ b/advocate_europe/templates/account/email/password_reset_key.en.email
@@ -1,0 +1,16 @@
+{% extends 'email_base.'|add:part_type %}
+
+{% block subject %}Reset password request for {{ site.name }}{% endblock %}
+
+{% block headline %}Password reset for your account {{ receiver.username }}{% endblock %}
+
+{% block content %}
+You have requested a password reset for your account on <i>{{ site.name }}</i>. Please click the  {% if part_type == 'txt' %}link{% else %}button{% endif %} below to set your new password.
+{% endblock %}
+
+{% block cta_url %}{{ password_reset_url }}{% endblock %}
+{% block cta_label %}Reset password{% endblock %}
+
+{% block reason %}
+You receive this email because you have an account on {{ site.name }} with email address {{ receiver.email }}. If you haven't requested a password reset, someone else might have done it on your behalf. In that case you can safely ignore this email, we won't change your password of modify your account.
+{% endblock %}

--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -1,0 +1,42 @@
+import re
+
+from allauth.account.adapter import DefaultAccountAdapter
+from django.utils.http import is_safe_url
+
+from adhocracy4.emails import Email
+from adhocracy4.emails.mixins import SyncEmailMixin
+from apps.users import USERNAME_REGEX
+
+
+class AccountEmail(Email, SyncEmailMixin):
+    def get_receivers(self):
+        return [self.object]
+
+    @property
+    def template_name(self):
+        return self.kwargs['template_name']
+
+
+class AccountAdapter(DefaultAccountAdapter):
+    username_regex = re.compile(USERNAME_REGEX)
+
+    def get_email_confirmation_url(self, request, emailconfirmation):
+        url = super().get_email_confirmation_url(request, emailconfirmation)
+        if 'next' in request.POST and is_safe_url(request.POST['next']):
+            return '{}?next={}'.format(url, request.POST['next'])
+        else:
+            return url
+
+    def send_mail(self, template_prefix, email, context):
+        user = context['user']
+        return AccountEmail.send(
+            user,
+            template_name=template_prefix,
+            **context
+        )
+
+    def get_email_confirmation_redirect_url(self, request):
+        if 'next' in request.GET and is_safe_url(request.GET['next']):
+            return request.GET['next']
+        else:
+            return super().get_email_confirmation_redirect_url(request)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import factory
 import pytest
+from django.core.urlresolvers import reverse
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
@@ -32,3 +33,8 @@ def image():
 @pytest.fixture
 def apiclient():
     return APIClient()
+
+
+@pytest.fixture
+def signup_url():
+    return reverse('account_signup')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,8 @@
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
+
+from django.core.urlresolvers import resolve
 from freezegun import freeze_time
 
 
@@ -19,3 +22,10 @@ def active_phase(module, phase_type):
         yield
 
     phase.delete()
+
+
+def redirect_target(response):
+    if response.status_code not in [301, 302]:
+        raise Exception("Response wasn't a redirect")
+    location = urlparse(response['location'])
+    return resolve(location.path).url_name

--- a/tests/users/test_users_emails.py
+++ b/tests/users/test_users_emails.py
@@ -1,0 +1,107 @@
+import re
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.contrib import auth
+from django.core import mail
+from django.core.urlresolvers import reverse
+
+from tests.helpers import redirect_target
+
+User = auth.get_user_model()
+
+
+@pytest.mark.django_db
+def test_register(client, signup_url):
+    assert EmailAddress.objects.count() == 0
+    email = 'testuser@liqd.de'
+    response = client.post(
+        signup_url, {
+            'username': 'testuser2',
+            'email': email,
+            'password1': 'password',
+            'password2': 'password',
+            'terms_of_use': 'on'
+        }
+    )
+    assert response.status_code == 302
+    assert EmailAddress.objects.filter(
+        email=email, verified=False
+    ).count() == 1
+    assert len(mail.outbox) == 1
+    confirmation_url = re.search(
+        r'(http://testserver/.*/)',
+        str(mail.outbox[0].body)
+    ).group(0)
+
+    confirm_email_response = client.get(confirmation_url)
+    assert confirm_email_response.status_code == 200
+    assert EmailAddress.objects.filter(
+        email=email, verified=False
+    ).count() == 1
+    confirm_email_response = client.post(confirmation_url)
+    assert confirm_email_response.status_code == 302
+    assert EmailAddress.objects.filter(
+        email=email, verified=True
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_register_with_next(client, signup_url):
+    assert EmailAddress.objects.count() == 0
+    email = 'testuser@liqd.de'
+    response = client.post(
+        signup_url, {
+            'username': 'testuser2',
+            'email': email,
+            'password1': 'password',
+            'password2': 'password',
+            'terms_of_use': 'on',
+            'next': '/en/ideas/pppp/',
+        }
+    )
+    assert response.status_code == 302
+    assert EmailAddress.objects.filter(
+        email=email, verified=False
+    ).count() == 1
+    assert len(mail.outbox) == 1
+    confirmation_url = re.search(
+        r'(http://testserver/.*/?next=/en/ideas/pppp/)',
+        str(mail.outbox[0].body)
+    ).group(0)
+    confirm_email_response = client.get(confirmation_url)
+    assert confirm_email_response.status_code == 200
+    assert EmailAddress.objects.filter(
+        email=email, verified=False
+    ).count() == 1
+    confirm_email_response = client.post(confirmation_url)
+    assert confirm_email_response.status_code == 302
+    assert redirect_target(confirm_email_response) == "idea-detail"
+    assert EmailAddress.objects.filter(
+        email=email, verified=True
+    ).count() == 1
+
+
+@pytest.mark.django_db
+def test_reset(client, user):
+    user.emailaddress_set.create(email=user.email, verified=True)
+    user.save()
+    reset_req_url = reverse('account_reset_password')
+    response = client.get(reset_req_url)
+    assert response.status_code == 200
+    response = client.post(reset_req_url, {'email': user.email})
+    assert response.status_code == 302
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to == [user.email]
+    reset_url = re.search(
+        r'(http://testserver/.*/)', str(mail.outbox[0].body)
+    ).group(0)
+    response = client.get(reset_url)
+    assert response.status_code == 200
+    response = client.post(reset_url, {
+        'password1': 'password1',
+        'password2': 'password1',
+    })
+    assert response.status_code == 302
+    assert response.url == '/'
+    assert user.password != User.objects.get(username=user.username).password


### PR DESCRIPTION
fixes #351 

I also found it in meinBerlin, so I think it should be moved to core.
With the changes to the email-sending in core, it will not work in OPIN anymore when we update a4. Do we have a place to note down stuff like that?