### PR TITLE
Ka 2017 09 styling reset password

### DIFF
--- a/advocate_europe/assets/scss/all.scss
+++ b/advocate_europe/assets/scss/all.scss
@@ -7,6 +7,7 @@
 @import "core/util";
 @import "core/buttons";
 
+@import "components/account";
 @import "components/activity";
 @import "components/avatar";
 @import "components/blocks";

--- a/advocate_europe/assets/scss/components/_account.scss
+++ b/advocate_europe/assets/scss/components/_account.scss
@@ -1,0 +1,27 @@
+.account-top {
+    @media screen and (min-width: $screen-md-min) {
+        padding-top: rem(60px);
+        padding-bottom: rem(60px);
+    }
+
+    @media screen and (max-width: $screen-sm-max) {
+        padding-top: rem(40px);
+        padding-bottom: rem(40px);
+    }
+
+    background: linear-gradient(to bottom, $brand-primary rem(162px), #fff 0%);
+}
+
+.account-box {
+    box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.2);
+    background-color: #fff;
+    border-radius: 4px;
+
+    @media screen and (min-width: $screen-sm-min) {
+        padding: rem(30px 60px);
+    }
+
+    @media screen and (max-width: $screen-xs-max) {
+        padding: rem(10px 10px);
+    }
+}

--- a/advocate_europe/assets/scss/components/_custom_form.scss
+++ b/advocate_europe/assets/scss/components/_custom_form.scss
@@ -78,6 +78,7 @@
 .form-link {
     font-weight: bold;
     font-size: rem(16px);
-    margin-bottom: 30px;
-    text-align: end;
+    margin-top: rem(-20px);
+    margin-bottom: rem(30px);
+    text-transform: capitalize;
 }

--- a/advocate_europe/templates/account/account_inactive.html
+++ b/advocate_europe/templates/account/account_inactive.html
@@ -5,8 +5,12 @@
 {% block title %}{% trans "Account Inactive" %}{% endblock %}
 
 {% block content %}
-<main class="container">
-    <h2>{% trans "Account Inactive" %}</h2>
-    <p>{% trans "This account is inactive." %}</p>
-</main>
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            <h2>{% trans "Account Inactive" %}</h2>
+            <p>{% trans "This account is inactive." %}</p>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/advocate_europe/templates/account/email_confirm.html
+++ b/advocate_europe/templates/account/email_confirm.html
@@ -6,26 +6,30 @@
 {% block title %}{% trans 'Activate your account' %}{% endblock %}
 
 {% block content %}
-<main class="container">
-{% if confirmation %}
-    {% user_display confirmation.email_address.user as user_display %}
-    <form id="ActivateForm" method="post">
-        {% csrf_token %}
-        <h2>{% trans 'Welcome to Advocate Europe!' %}</h2>
-        <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
-        {% if form.non_field_errors %}
-            <div class="form-errors">
-            {% for error in form.non_field_errors %}
-                <p class="alert alert-danger">{{ error }}</p>
-            {% endfor %}
-            </div>
-        {% endif %}
-        <button type="submit" value="Activate" class="btn btn-ae-secondary">{% trans "Activate account" %}</button>
-    </form>
-{% else %}
-    <h2>{% trans 'Welcome to Advocate Europe!' %}</h2>
-    {% url 'account_email' as email_url %}
-    <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
-{% endif %}
-</main>
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            {% if confirmation %}
+                {% user_display confirmation.email_address.user as user_display %}
+                <form id="ActivateForm" method="post">
+                    {% csrf_token %}
+                    <h2>{% trans 'Welcome to Advocate Europe!' %}</h2>
+                    <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+                    {% if form.non_field_errors %}
+                        <div class="form-errors">
+                        {% for error in form.non_field_errors %}
+                            <p class="alert alert-danger">{{ error }}</p>
+                        {% endfor %}
+                        </div>
+                    {% endif %}
+                    <button type="submit" value="Activate" class="btn btn-ae-secondary">{% trans "Activate account" %}</button>
+                </form>
+            {% else %}
+                <h2>{% trans 'Welcome to Advocate Europe!' %}</h2>
+                {% url 'account_email' as email_url %}
+                <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/advocate_europe/templates/account/password_reset.html
+++ b/advocate_europe/templates/account/password_reset.html
@@ -7,25 +7,30 @@
 {% block title %}{% trans 'Reset your password' %}{% endblock %}
 
 {% block content %}
-<main class="container">
-    <form role="form" name="RegisterForm" action="{% url 'account_reset_password' %}" method="post" >
-        <p>{% trans "Enter your e-mail address below, and we'll send you an e-mail allowing you to reset your password." %}</p>
-        {% csrf_token %}
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            <form class="custom-form" role="form" name="RegisterForm" action="{% url 'account_reset_password' %}" method="post" >
+                <h2>{% trans "Reset your password" %}</h2>
+                <p>{% trans "Enter your e-mail address below, and we'll send you an e-mail allowing you to reset your password." %}</p>
+                {% csrf_token %}
 
-        {% if form.non_field_errors %}
-            <div class="form-errors">
-            {% for error in form.non_field_errors %}
-                <p class="alert alert-danger">{{ error }}</p>
-            {% endfor %}
-            </div>
-        {% endif %}
+                {% if form.non_field_errors %}
+                    <div class="form-errors">
+                    {% for error in form.non_field_errors %}
+                        <p class="alert alert-danger">{{ error }}</p>
+                    {% endfor %}
+                    </div>
+                {% endif %}
 
-        <div class="form-group">
-            <label class="control-label" for="{{ form.email.id_for_label }}">{% trans "Email" %}</label>
-            {{ form.email.errors }}
-            {{ form.email|add_class:"form-control" }}
+                <div class="form-group">
+                    <label class="control-label" for="{{ form.email.id_for_label }}">{% trans "Email" %}</label>
+                    {{ form.email.errors }}
+                    {{ form.email|add_class:"form-control" }}
+                </div>
+                <button type="submit" value="reset" class="btn btn-ae-secondary">{% trans "Reset" %}</button>
+            </form>
         </div>
-        <button type="submit" value="reset" class="btn btn-ae-secondary">{% trans "Reset" %}</button>
-    </form>
-</main>
+    </div>
+</div>
 {% endblock %}

--- a/advocate_europe/templates/account/password_reset_done.html
+++ b/advocate_europe/templates/account/password_reset_done.html
@@ -6,8 +6,12 @@
 {% block title %}{% trans 'Password reset' %}{% endblock %}
 
 {% block content %}
-<main class="container">
-    <h2>{% trans "Password reset" %}</h2>
-    <p>{% trans "We have sent you an e-mail. Please contact us if you do not receive it within a few minutes." %}</p>
-</main>
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            <h2>{% trans "Password reset" %}</h2>
+            <p>{% trans "We have sent you an e-mail. Please contact us if you do not receive it within a few minutes." %}</p>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/advocate_europe/templates/account/password_reset_from_key.html
+++ b/advocate_europe/templates/account/password_reset_from_key.html
@@ -6,47 +6,52 @@
 {% block title %}{% trans 'Reset your password' %}{% endblock %}
 
 {% block content %}
-<main class="container">
-    {% if token_fail %}
-    <h2>{% trans "Bad Token" %}</h2>
-    {% url 'account_reset_password' as passwd_reset_url %}
-    <p>
-        {% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}
-    </p>
-    {% else %}
-    {% if form %}
-    <form role="form" name="ResetPasswordForm" action="" method="post">
-        {% csrf_token %}
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            {% if token_fail %}
+            <h2>{% trans "Bad Token" %}</h2>
+            {% url 'account_reset_password' as passwd_reset_url %}
+            <p>
+                {% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}
+            </p>
+            {% else %}
+            {% if form %}
+            <form class="custom-form" role="form" name="ResetPasswordForm" action="" method="post">
+                <h2>{% trans "Reset your password" %}</h2>
+                {% csrf_token %}
 
-        {% if form.non_field_errors %}
-        <div class="form-errors">
-            {% for error in form.non_field_errors %}
-            <p class="alert alert-danger">{{ error }}</p>
-            {% endfor %}
+                {% if form.non_field_errors %}
+                <div class="form-errors">
+                    {% for error in form.non_field_errors %}
+                    <p class="alert alert-danger">{{ error }}</p>
+                    {% endfor %}
+                </div>
+                {% endif %}
+
+                {{ form.token }}
+                {{ form.token.errors }}
+
+                <div class="form-group">
+                    <label class="control-label" for="{{ form.password1.id_for_label }}">{% trans "Password" %}</label>
+                    {{ form.password1.errors }}
+                    {{ form.password1|add_class:"form-control" }}
+                </div>
+
+                <div class="form-group">
+                    <label class="control-label" for="{{ form.password2.id_for_label }}">{% trans "Repeat password" %}</label>
+                    {{ form.password2.errors }}
+                    {{ form.password2|add_class:"form-control" }}
+                </div>
+
+                <button type="submit" value="Activate" class="btn btn-ae-secondary">{% trans "Reset password" %}</button>
+            </form>
+            {% else %}
+            <h2>{% trans "Change password" %}</h2>
+            <p>{% trans 'Your password is now changed.' %}</p>
+            {% endif %}
+            {% endif %}
         </div>
-        {% endif %}
-
-        {{ form.token }}
-        {{ form.token.errors }}
-
-        <div class="form-group">
-            <label class="control-label" for="{{ form.password1.id_for_label }}">{% trans "Password" %}</label>
-            {{ form.password1.errors }}
-            {{ form.password1|add_class:"form-control" }}
-        </div>
-
-        <div class="form-group">
-            <label class="control-label" for="{{ form.password2.id_for_label }}">{% trans "Repeat password" %}</label>
-            {{ form.password2.errors }}
-            {{ form.password2|add_class:"form-control" }}
-        </div>
-
-        <button type="submit" value="Activate" class="btn btn-ae-secondary">{% trans "Reset password" %}</button>
-    </form>
-    {% else %}
-    <h2>{% trans "Change password" %}</h2>
-    <p><small>{% trans 'Your password is now changed.' %}</small></p>
-    {% endif %}
-    {% endif %}
-</main>
+    </div>
+</div>
 {% endblock %}

--- a/advocate_europe/templates/account/password_reset_from_key_done.html
+++ b/advocate_europe/templates/account/password_reset_from_key_done.html
@@ -5,8 +5,12 @@
 {% block title %}{% trans "Change password" %}{% endblock %}
 
 {% block content %}
-<div class="container">
-    <h2>{% trans "Change password" %}</h2>
-    <p>{% trans "Your password is now changed." %}</p>
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            <h2>{% trans "Change password" %}</h2>
+            <p>{% trans "Your password is now changed." %}</p>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/advocate_europe/templates/account/password_set.html
+++ b/advocate_europe/templates/account/password_set.html
@@ -6,8 +6,6 @@
 {% block title %}{% trans "Change Password" %}{% endblock %}
 
 {% block form %}
-
-
     <form class="custom-form" role="form" name="PasswordSetForm"
           action="{% url 'account_set_password' %}" method="post">
         {% csrf_token %}

--- a/advocate_europe/templates/account/verification_sent.html
+++ b/advocate_europe/templates/account/verification_sent.html
@@ -5,8 +5,12 @@
 {% block title %}{% trans 'Verify Your E-mail Address' %}{% endblock %}
 
 {% block content %}
-<main class="container">
-    <h2>{% trans "Verify Your E-mail Address" %}</h2>
-    <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
-</main>
+<div class="account-top">
+    <div class="container">
+        <div class="container-medium account-box">
+            <h2>{% trans "Verify Your E-mail Address" %}</h2>
+            <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/apps/users/adapters.py
+++ b/apps/users/adapters.py
@@ -5,10 +5,11 @@ from django.utils.http import is_safe_url
 
 from adhocracy4.emails import Email
 from adhocracy4.emails.mixins import SyncEmailMixin
+from apps.notifications.emails import SVGLogoMixin
 from apps.users import USERNAME_REGEX
 
 
-class AccountEmail(Email, SyncEmailMixin):
+class AccountEmail(SVGLogoMixin, Email, SyncEmailMixin):
     def get_receivers(self):
         return [self.object]
 


### PR DESCRIPTION
fixes #403,
fixes #412 - all the templates in account are styled now, apart from
- email.html
- password_change.html, which are both used in the user settings, so are styled there and
- password_set.html, where I couldn't find where it's used. When I try to access it via url, I am redirected to password_change.