### PR TITLE
Ka 2017 10 link co workers in edit

### DIFF
--- a/advocate_europe/assets/scss/components/_userpicker.scss
+++ b/advocate_europe/assets/scss/components/_userpicker.scss
@@ -31,6 +31,11 @@
         padding-left: rem(6px);
         font-size: rem(14px);
         font-weight: $demibold;
+
+        a {
+            color: $gray-dark;
+            text-decoration: none;
+        }
     }
 
     &-label-detail {

--- a/advocate_europe/templates/bootstrap3/user_checkboxselectmultiple.html
+++ b/advocate_europe/templates/bootstrap3/user_checkboxselectmultiple.html
@@ -19,7 +19,13 @@
             {% if user.avatar %}
             <span class="avatar-round-small" style="background-image: url({{ user.avatar }});"></span>
             {% endif %}
-            <span class="user-picker-label-text">{{ user.username|unlocalize }}</span>
+            <span class="user-picker-label-text">
+            {% if not user.detail %}
+            <a href="{% url 'profile' user.username %}">{{ user.username|unlocalize }}</a>
+            {% else %}
+            {{ user.username|unlocalize }}
+            {% endif %}
+            </span>
             {% if user.detail %}
             <span class="user-picker-label-text user-picker-label-detail">{{ user.detail|unlocalize }}</span>
             {% endif %}

--- a/advocate_europe/templates/bootstrap3/user_checkboxselectmultiple.html
+++ b/advocate_europe/templates/bootstrap3/user_checkboxselectmultiple.html
@@ -31,8 +31,13 @@
             {% elif user.username == request.user.username %}
             <span class="user-picker-label-text user-picker-label-detail">This is you!</span>
             {% endif %}
+            {% if user.username == request.user.username %}
+            <div class="user-picker-cta user-picker-cta-checked btn-link">Leave team</div>
+            <div class="user-picker-cta user-picker-cta-unchecked btn-link">You will be removed on save</div>
+            {% else %}
             <div class="user-picker-cta user-picker-cta-checked btn-link">{{ user.cta_checked }}</div>
             <div class="user-picker-cta user-picker-cta-unchecked btn-link">{{ user.cta_unchecked }}</div>
+            {% endif %}
         </div>
     </label>
     {% if not inline_class %}</div>{% endif %}

--- a/advocate_europe/templates/bootstrap3/user_checkboxselectmultiple.html
+++ b/advocate_europe/templates/bootstrap3/user_checkboxselectmultiple.html
@@ -28,6 +28,8 @@
             </span>
             {% if user.detail %}
             <span class="user-picker-label-text user-picker-label-detail">{{ user.detail|unlocalize }}</span>
+            {% elif user.username == request.user.username %}
+            <span class="user-picker-label-text user-picker-label-detail">This is you!</span>
             {% endif %}
             <div class="user-picker-cta user-picker-cta-checked btn-link">{{ user.cta_checked }}</div>
             <div class="user-picker-cta user-picker-cta-unchecked btn-link">{{ user.cta_unchecked }}</div>


### PR DESCRIPTION
- fixes one of the issues in #516 (link profiles from collaborator edit form)

- also checks if current user is a team-member and let's him know it's him (according to design)