### PR TITLE
Enable cache busting in production

### DIFF
--- a/advocate_europe/settings/build.py
+++ b/advocate_europe/settings/build.py
@@ -1,3 +1,5 @@
 from .base import *
 
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+
 SECRET_KEY = "dummykeyforbuilding"

--- a/advocate_europe/settings/production.py
+++ b/advocate_europe/settings/production.py
@@ -5,6 +5,8 @@ COMPRESS_OFFLINE = True
 
 DEBUG = False
 
+STATICFILES_STORAGE = 'advocate_europe.apps.contrib.staticfiles.NonStrictManifestStaticFilesStorage'
+
 try:
     from .local import *
 except ImportError:

--- a/advocate_europe/settings/production.py
+++ b/advocate_europe/settings/production.py
@@ -1,11 +1,8 @@
 from .base import *
 
-COMPRESS = True
-COMPRESS_OFFLINE = True
-
 DEBUG = False
 
-STATICFILES_STORAGE = 'advocate_europe.apps.contrib.staticfiles.NonStrictManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 try:
     from .local import *

--- a/apps/contrib/staticfiles.py
+++ b/apps/contrib/staticfiles.py
@@ -1,5 +1,0 @@
-from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
-
-
-class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
-    manifest_strict = False

--- a/apps/contrib/staticfiles.py
+++ b/apps/contrib/staticfiles.py
@@ -1,0 +1,5 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    manifest_strict = False


### PR DESCRIPTION
Enable the `ManifestStaticFilesStorage`\[1\] (non strict) on productions.

It adds hashes to all static files collected with collectstatic providing cache busting and allowing to cache them forever (needs to be configured on the web server).

The build server needs to be configured to run collectstatic twice. Once with the build configuration and once with the production configuration. Added the `collectstatic_prod` build step to our build script for this.

\[1\] https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/#manifeststaticfilesstorage