### PR TITLE
Enable collapsibles in project information 

### DIFF
--- a/advocate_europe/settings/base.py
+++ b/advocate_europe/settings/base.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     'adhocracy4.actions.apps.ActionsConfig',
     'adhocracy4.filters.apps.FiltersConfig',
     'adhocracy4.rules.apps.RulesConfig',
+    'adhocracy4.ckeditor.apps.CKEditorConfig',
 
     'cms.home.apps.HomeConfig',
     'cms.settings.apps.SettingsConfig',
@@ -180,6 +181,17 @@ CKEDITOR_CONFIGS = {
             ['NumberedList', 'BulletedList'],
             ['Link', 'Unlink']
         ]
+    },
+    'collapsible-image-editor': {
+        'width': '100%',
+        'toolbar': 'Custom',
+        'toolbar_Custom': [
+            ['Bold', 'Italic', 'Underline'],
+            ['Image'],
+            ['NumberedList', 'BulletedList'],
+            ['Link', 'Unlink'],
+            ['CollapsibleItem']
+        ]
     }
 }
 
@@ -195,6 +207,26 @@ BLEACH_LIST = {
         'attributes': {
             'a': ['href', 'rel'],
             'img': ['src', 'alt', 'style']
+        },
+        'styles': [
+            'float',
+            'margin',
+            'padding',
+            'width',
+            'height',
+            'margin-bottom',
+            'margin-top',
+            'margin-left',
+            'margin-right',
+        ],
+    },
+    'image-editor': {
+        'tags': ['p', 'strong', 'em', 'u', 'ol', 'li', 'ul', 'a', 'img',
+                 'div'],
+        'attributes': {
+            'a': ['href', 'rel'],
+            'img': ['src', 'alt', 'style'],
+            'div': ['class']
         },
         'styles': [
             'float',

--- a/advocate_europe/settings/base.py
+++ b/advocate_europe/settings/base.py
@@ -220,7 +220,7 @@ BLEACH_LIST = {
             'margin-right',
         ],
     },
-    'image-editor': {
+    'collapsible-image-editor': {
         'tags': ['p', 'strong', 'em', 'u', 'ol', 'li', 'ul', 'a', 'img',
                  'div'],
         'attributes': {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "advocate_europe",
   "dependencies": {
-    "adhocracy4": "liqd/adhocracy4#6fbf817762a76bf4112abb7477e92006273141bb",
+    "adhocracy4": "liqd/adhocracy4#5c5a5f5a811c37410e683941673a3712564ea019",
     "autoprefixer": "7.2.5",
     "babel-core": "6.17.0",
     "babel-loader": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "advocate_europe",
   "dependencies": {
-    "adhocracy4": "liqd/adhocracy4#5c5a5f5a811c37410e683941673a3712564ea019",
+    "adhocracy4": "liqd/adhocracy4#0432f796118d2fe918e6851f64916bae18e4c8e3",
     "autoprefixer": "7.2.5",
     "babel-core": "6.17.0",
     "babel-loader": "7.1.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-git+git://github.com/liqd/adhocracy4.git@6fbf817762a76bf4112abb7477e92006273141bb
+git+git://github.com/liqd/adhocracy4.git@5c5a5f5a811c37410e683941673a3712564ea019
 bcrypt==3.1.4
 Django==1.11.9 # pyup: >=1.11,<1.12
 wagtail==1.11.1 # pyup: ignore # disable until we fix block on homepage

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-git+git://github.com/liqd/adhocracy4.git@5c5a5f5a811c37410e683941673a3712564ea019
+git+git://github.com/liqd/adhocracy4.git@0432f796118d2fe918e6851f64916bae18e4c8e3
 bcrypt==3.1.4
 Django==1.11.9 # pyup: >=1.11,<1.12
 wagtail==1.11.1 # pyup: ignore # disable until we fix block on homepage


### PR DESCRIPTION
depends on liqd/adhocracy4#235

Note, that the dependencies are currently pointing to the last commit within the PR. maybe we should update them to the merge commit after a4 has been merged