### PR TITLE
Remove check if image exists on filesystem

### DIFF
--- a/apps/ideas/models/abstracts/idea_section.py
+++ b/apps/ideas/models/abstracts/idea_section.py
@@ -118,14 +118,3 @@ class AbstractIdeaSection(models.Model):
         if self.idea_topics_other:
             idea_topics.append(self.idea_topics_other)
         return idea_topics
-
-    @property
-    def idea_image_exists(self):
-        if self.idea_image:
-            try:
-                self.idea_image.width
-                return True
-            except FileNotFoundError:
-                return False
-        else:
-            return False

--- a/apps/ideas/templates/advocate_europe_ideas/idea_detail.html
+++ b/apps/ideas/templates/advocate_europe_ideas/idea_detail.html
@@ -9,7 +9,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Advocate Europe | {{ idea.idea_title }}">
     <meta name="twitter:description" content="{{ idea.idea_pitch }}">
-    {% if idea.idea_image_exists %}
+    {% if idea.idea_image %}
         <meta name="twitter:image" content="{% get_absolute_uri obj=idea.idea_image.url %}">
     {% else %}
         <meta name="twitter:image" content="{% get_absolute_uri_static obj='images/logo_01.png' %}">
@@ -19,7 +19,7 @@
     <meta property="og:url" content="{{ request.build_absolute_uri }}">
     <meta property="og:title" content="Advocate Europe | {{ idea.idea_title }}">
     <meta property="og:description" content="{{ idea.idea_pitch }}">
-    {% if idea.idea_image_exists %}
+    {% if idea.idea_image %}
         <meta property="og:image" content="{% get_absolute_uri obj=idea.idea_image.url %}">
         <meta property="og:image:width" content="{{ idea.idea_image.width }}">
         <meta property="og:image:height" content="{{ idea.idea_image.height }}">

--- a/apps/ideas/templates/advocate_europe_ideas/includes/idea_detail_header.html
+++ b/apps/ideas/templates/advocate_europe_ideas/includes/idea_detail_header.html
@@ -1,7 +1,7 @@
 {% load i18n static react_ratings idea_tags thumbnail rules %}
 
 <div class="row ideadetail-header">
-    <div class="ideadetail-image" style="background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), #000000), url({% if idea.idea_image_exists %} {{ idea.idea_image|thumbnail_url:'ideadetailimage' }} {% else %} {% static 'images/placeholder_blue.svg' %} {% endif %});">
+    <div class="ideadetail-image" style="background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), #000000), url({% if idea.idea_image %} {{ idea.idea_image|thumbnail_url:'ideadetailimage' }} {% else %} {% static 'images/placeholder_blue.svg' %} {% endif %});">
         <div class="ideadetailheader-content">
             <div class="col-md-9 col-sm-8 col-xs-12 ideadetailheader-left">
                 <div class="ideadetail-btn">

--- a/apps/ideas/templates/advocate_europe_ideas/includes/idealist_item.html
+++ b/apps/ideas/templates/advocate_europe_ideas/includes/idealist_item.html
@@ -2,7 +2,7 @@
 <div class="idealist-item">
     <div class="idealist-upper">
         <a class="idealist-image hover-parent" href="{% url 'idea-detail' slug=idea.slug %}" tabindex="-1">
-            <img class="hover-child-img" src="{% if idea.idea_image_exists %} {{ idea.idea_image|thumbnail_url:'ideatileimage' }} {% else %} {% static 'images/placeholder_blue.svg' %} {% endif %}"/>
+            <img class="hover-child-img" src="{% if idea.idea_image %} {{ idea.idea_image|thumbnail_url:'ideatileimage' }} {% else %} {% static 'images/placeholder_blue.svg' %} {% endif %}"/>
             {% if idea.badge %}
             <span class="label idealist-label {{ idea.badge|cut:" " }}">{{ idea.badge }}</span>
             {% endif %}


### PR DESCRIPTION
This removes the check if a image path stored in the DB does actually
point to a valid image file on the filesystem, as this emerged to be a
major performance problem.
The image path in the DB should only be set if the image was
successfully uploaded. On the dev,stage and prod servers every image
stored in the DB is also present on the filesystem. The following
command was used to check the images:
```for image in `sudo -u django psql -c "SELECT idea_image FROM
advocate_europe_ideas_idea WHERE idea_image != '';"`; do if [ ! -e
/home/django/django/media/$image ]; then echo $image; fi; done```

If the idea_image_exists is still needed it is advised to use
`os.path.exists` should be used instead of checking the width, as
checking the width includes opening and analyzing the file via PIL