### PR TITLE
settings: Use legacy wagtail editor

### DIFF
--- a/advocate_europe/settings/base.py
+++ b/advocate_europe/settings/base.py
@@ -376,3 +376,9 @@ A4_ACTIONABLES = (
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 CRISPY_FAIL_SILENTLY = False
+
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    'default': {
+        'WIDGET': 'wagtail.admin.rich_text.HalloRichTextArea'
+    }
+}


### PR DESCRIPTION
We currently can't set dictionaries in the salt config, therefore
do it here.

Fixes #898