### PR TITLE
Update to wagtail 2.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 git+git://github.com/liqd/adhocracy4.git@ae-v0.10#egg=adhocracy4
 Django==2.2
-wagtail==2.4
+wagtail==2.5
 
 appdirs==1.4.3
 bcrypt==3.1.6

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,5 @@
-const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const merge = require('webpack-merge');
 
 module.exports = merge(common, {
    devtool: 'eval'

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,15 +1,9 @@
-const webpack = require('webpack');
-const merge = require('webpack-merge');
-const TerserPlugin = require('terser-webpack-plugin')
 const common = require('./webpack.common.js');
+const merge = require('webpack-merge')
+const TerserPlugin = require('terser-webpack-plugin')
 
 module.exports = merge(common, {
   devtool: 'source-map',
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production')
-    })
-  ],
   optimization: {
     minimizer: [
       new TerserPlugin({


### PR DESCRIPTION
This brings official support for django 2.2 and has a workaround for the broken editor (https://github.com/freedomofpress/securedrop.org/pull/621). The root cause for that is not yet fixed though (https://github.com/wagtail/wagtail/issues/4602)